### PR TITLE
Restructured + Leak fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ A simple library to make it easy requesting permissions in Android using Kotlin 
 
 #### Gradle:
 
-Add following line of code to your module(app) level gradle file
+Add following line of code to your module (app) level gradle file:
 
 ```groovy
-    implementation 'com.innfinity:PermissionsFlow:1.0.1'
+    implementation 'com.innfinity:PermissionsFlow:<LATEST-VERSION>'
 ```
 
 #### Maven:
@@ -25,31 +25,37 @@ Add following line of code to your module(app) level gradle file
   </dependency>
 ```
 
-## Usage
+###
 
-You need to implement few steps use the library.
+Permission flow offers 2 simple extension functions - both for for activities/fragments:
 
 ```kotlin
-  // Open a block of PermissionFlow
-  permissionFlow {
-    // specify permissions you want to request 
-    withPermissions(Manifest.permission.CAMERA,Manifest.permission.WRITE_EXTERNAL_STORAGE)
+requestPermissions(vararg permissionsToRequest: String)
+requestEachPermissions(vararg permissionsToRequest: String)
+```
 
-    // add an instance of the fragment or activity, from where you are requesting permissions
-    withActivity(this@MainActivity)
-    //or
-    withFragment(this@MainFragment)
+Both functions do request all permissions passed to them - the first one emits a list of `Permissions`, the second one flattens the permissions.
 
-    //request for permissions
-    request().collect { granted: Boolean ->
-      // do something with result
-    }
-    //or
-    requestEach().collect { permission: Permission ->
-      // get result for each permission and see if it is either granted 
-      // or not, or should show a rationale explanation
-    }
-  }
+Here's a full code example like it would look like in an activity:
+
+
+```kotlin
+override fun onCreate(savedInstanceState: Bundle?) {
+ 
+     CoroutineScope(Dispatchers.Main).launch {
+	    // just call requestPermission and pass in all required permissions
+		requestPermissions(Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+			.collect { permissions ->
+				// here you get the result of the requests, permissions holds a list of Permission requests and you can check if all of them have been granted:
+				val allGranted = !permissions.map { it.isGranted }.contains(false)
+				// or iterate over the permissions and check them one by one
+				permissions.forEach { 
+					val granted = it.isGranted
+					// ...
+				}
+			}
+	}
+}
 ```
 
 ## That's it!

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add following line of code to your module (app) level gradle file:
   </dependency>
 ```
 
-###
+### Usage:
 
 Permission flow offers 2 simple extension functions - both for for activities/fragments:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Permissions Flow
 [ ![Download](https://api.bintray.com/packages/innfinity-am/maven/PermissionsFlow/images/download.svg) ](https://bintray.com/innfinity-am/maven/PermissionsFlow/_latestVersion)
-[![API](https://img.shields.io/badge/API-23%2B-yellow.svg?style=flat)](https://android-arsenal.com/api?level=21)
+[![API](https://img.shields.io/badge/API-21%2B-yellow.svg?style=flat)](https://android-arsenal.com/api?level=21)
 
 A simple library to make it easy requesting permissions in Android using Kotlin Coroutines.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ override fun onCreate(savedInstanceState: Bundle?) {
         requestPermissions(Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE)
             .collect { permissions ->
                 // here you get the result of the requests, permissions holds a list of Permission requests and you can check if all of them have been granted:
-                val allGranted = !permissions.map { it.isGranted }.contains(false)
+                val allGranted = permissions.find { !it.isGranted } == null
                 // or iterate over the permissions and check them one by one
                 permissions.forEach { 
                 	val granted = it.isGranted

--- a/README.md
+++ b/README.md
@@ -42,18 +42,18 @@ Here's a full code example like it would look like in an activity:
 ```kotlin
 override fun onCreate(savedInstanceState: Bundle?) {
  
-     CoroutineScope(Dispatchers.Main).launch {
-	    // just call requestPermission and pass in all required permissions
-		requestPermissions(Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE)
-			.collect { permissions ->
-				// here you get the result of the requests, permissions holds a list of Permission requests and you can check if all of them have been granted:
-				val allGranted = !permissions.map { it.isGranted }.contains(false)
-				// or iterate over the permissions and check them one by one
-				permissions.forEach { 
-					val granted = it.isGranted
-					// ...
-				}
-			}
+    CoroutineScope(Dispatchers.Main).launch {
+        // just call requestPermission and pass in all required permissions
+        requestPermissions(Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            .collect { permissions ->
+                // here you get the result of the requests, permissions holds a list of Permission requests and you can check if all of them have been granted:
+                val allGranted = !permissions.map { it.isGranted }.contains(false)
+                // or iterate over the permissions and check them one by one
+                permissions.forEach { 
+                	val granted = it.isGranted
+                	// ...
+                }
+            }
 	}
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,17 @@
+apply from: './versions.gradle'
+
 buildscript {
-    ext.kotlin_version = '1.3.72'
-    ext.coroutine_version = '1.3.3'
+
+    apply from: './versions.gradle'
+
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.novoda:bintray-release:0.9.1'
+        classpath 'com.android.tools.build:gradle:' + versions.gradlePlugin
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:' + versions.kotlin
+        classpath 'com.novoda:bintray-release:' + versions.bintray
     }
 }
 

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -3,12 +3,13 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 29
+
+    compileSdkVersion setup.compileSdk
 
     defaultConfig {
         applicationId "com.innfinity.permissionflow"
-        minSdkVersion 23
-        targetSdkVersion 29
+        minSdkVersion setup.minSdk
+        targetSdkVersion setup.targetSdk
         versionCode 1
         versionName "1.0"
 
@@ -25,16 +26,15 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutine_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutine_version"
 
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutine}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.coroutine}"
 
-    implementation 'com.innfinity:PermissionsFlow:1.0.0'
+    implementation "androidx.appcompat:appcompat:${androidx.appcompat}"
+    implementation "androidx.core:core-ktx:${androidx.core}"
+
+    implementation project(":lib")
 
     testImplementation 'junit:junit:4.13'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/demo/src/main/java/com/innfinity/permissionflow/MainActivity.kt
+++ b/demo/src/main/java/com/innfinity/permissionflow/MainActivity.kt
@@ -3,9 +3,9 @@ package com.innfinity.permissionflow
 import android.Manifest
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import com.innfinity.permissionflow.lib.permissionFlow
-import com.innfinity.permissionflow.lib.withActivity
-import com.innfinity.permissionflow.lib.withPermissions
+import com.innfinity.permissionflow.lib.Permission
+import com.innfinity.permissionflow.lib.requestEachPermissions
+import com.innfinity.permissionflow.lib.requestPermissions
 import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -14,31 +14,31 @@ import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
 
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-
-        test.setOnClickListener {
+        tvState.text = "Permission results:"
+        btPermissionsAll.setOnClickListener {
             CoroutineScope(Dispatchers.Main).launch {
-                permissionFlow {
-                    withPermissions(
-                        Manifest.permission.CAMERA,
-                        Manifest.permission.WRITE_EXTERNAL_STORAGE
-                    )
-                    withActivity(this@MainActivity)
-
-                    //request all
-//                    request().collect { granted ->
-//                        println("PERMISSIONS $granted")
-//                    }
-
-                    //request sequentially
-                    requestEach().collect { permission ->
-                        println("PERMISSIONS $permission")
-                    }
-                }
+                this@MainActivity.requestPermissions(Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                        .collect { permissions ->
+                            permissions.forEach {
+                                appendInfo("[ALL]", it)
+                            }
+                        }
             }
         }
+        btPermissionsEach.setOnClickListener {
+            CoroutineScope(Dispatchers.Main).launch {
+                this@MainActivity.requestEachPermissions(Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                        .collect { permission ->
+                            appendInfo("[EACH]", permission)
+                        }
+            }
+        }
+    }
+
+    fun appendInfo(prefix: String, permission: Permission) {
+        tvState.text = "${tvState.text}\n$prefix ${permission.permission.substringAfterLast(".")} = ${permission.isGranted}"
     }
 }

--- a/demo/src/main/java/com/innfinity/permissionflow/MainActivity.kt
+++ b/demo/src/main/java/com/innfinity/permissionflow/MainActivity.kt
@@ -20,25 +20,25 @@ class MainActivity : AppCompatActivity() {
         tvState.text = "Permission results:"
         btPermissionsAll.setOnClickListener {
             CoroutineScope(Dispatchers.Main).launch {
-                this@MainActivity.requestPermissions(Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                        .collect { permissions ->
-                            permissions.forEach {
-                                appendInfo("[ALL]", it)
-                            }
+                requestPermissions(Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                    .collect { permissions ->
+                        permissions.forEach {
+                            appendInfo("[ALL]", it)
                         }
+                    }
             }
         }
         btPermissionsEach.setOnClickListener {
             CoroutineScope(Dispatchers.Main).launch {
-                this@MainActivity.requestEachPermissions(Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                        .collect { permission ->
-                            appendInfo("[EACH]", permission)
-                        }
+                requestEachPermissions(Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                    .collect { permission ->
+                        appendInfo("[EACH]", permission)
+                    }
             }
         }
     }
 
-    fun appendInfo(prefix: String, permission: Permission) {
+    private fun appendInfo(prefix: String, permission: Permission) {
         tvState.text = "${tvState.text}\n$prefix ${permission.permission.substringAfterLast(".")} = ${permission.isGranted}"
     }
 }

--- a/demo/src/main/java/com/innfinity/permissionflow/MainActivity.kt
+++ b/demo/src/main/java/com/innfinity/permissionflow/MainActivity.kt
@@ -22,6 +22,9 @@ class MainActivity : AppCompatActivity() {
             CoroutineScope(Dispatchers.Main).launch {
                 requestPermissions(Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE)
                     .collect { permissions ->
+                        // check if all permissions have been granted
+                        // val allGranted = permissions.find { !it.isGranted } == null
+                        // or check them one by one
                         permissions.forEach {
                             appendInfo("[ALL]", it)
                         }

--- a/demo/src/main/res/layout/activity_main.xml
+++ b/demo/src/main/res/layout/activity_main.xml
@@ -1,19 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     tools:context=".MainActivity">
 
-    <TextView
-        android:id="@+id/test"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <Button
+            android:id="@+id/btPermissionsAll"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Request ALL permissions" />
+
+        <Button
+            android:id="@+id/btPermissionsEach"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Request EACH permissions" />
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/tvState"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+
+</LinearLayout>

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-//apply plugin: 'com.novoda.bintray-release'
+apply plugin: 'com.novoda.bintray-release'
 
 android {
 
@@ -37,7 +37,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }
 
-/*publish {
+publish {
     groupId = 'com.innfinity'
     artifactId = 'PermissionsFlow'
     publishVersion = '1.0.2'
@@ -45,4 +45,4 @@ dependencies {
     licences = ['Apache-2.0']
     website = 'https://github.com/innfinity-am/PermissionsFlow'
     userOrg = 'innfinity-am'
-}*/
+}

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,17 +1,15 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-apply plugin: 'com.novoda.bintray-release'
+//apply plugin: 'com.novoda.bintray-release'
 
 android {
-    compileSdkVersion 29
+
+    compileSdkVersion setup.compileSdk
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
-
+        minSdkVersion setup.minSdk
+        targetSdkVersion setup.targetSdk
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
     }
@@ -26,20 +24,20 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutine_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutine_version"
 
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.3.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutine}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.coroutine}"
+
+    implementation "androidx.appcompat:appcompat:${androidx.appcompat}"
+    implementation "androidx.core:core-ktx:${androidx.core}"
 
     testImplementation 'junit:junit:4.13'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }
 
-publish {
+/*publish {
     groupId = 'com.innfinity'
     artifactId = 'PermissionsFlow'
     publishVersion = '1.0.2'
@@ -47,4 +45,4 @@ publish {
     licences = ['Apache-2.0']
     website = 'https://github.com/innfinity-am/PermissionsFlow'
     userOrg = 'innfinity-am'
-}
+}*/

--- a/lib/src/main/java/com/innfinity/permissionflow/lib/PermissionFlow.kt
+++ b/lib/src/main/java/com/innfinity/permissionflow/lib/PermissionFlow.kt
@@ -1,79 +1,56 @@
 package com.innfinity.permissionflow.lib
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentManager
 import kotlinx.coroutines.flow.flow
 
-object PermissionFlow {
+internal object PermissionFlow {
 
-    internal var permissionsToRequest: Array<out String> = emptyArray()
-    internal var fragmentInFlow: Fragment? = null
-    internal var activityInFlow: FragmentActivity? = null
+    private val FRAGMENT_TAG = PermissionFragment::class.java.simpleName
 
-    private var permissionFragment: PermissionFragment? = null
+    internal fun request(fragment: Fragment, vararg permissionsToRequest: String) = request(fragment.childFragmentManager, *permissionsToRequest)
+    internal fun request(activity: FragmentActivity, vararg permissionsToRequest: String) = request(activity.supportFragmentManager, *permissionsToRequest)
 
-    fun request() = flow {
-        createFragment()
+    internal fun requestEach(fragment: Fragment, vararg permissionsToRequest: String) = requestEach(fragment.childFragmentManager, *permissionsToRequest)
+    internal fun requestEach(activity: FragmentActivity, vararg permissionsToRequest: String) = requestEach(activity.supportFragmentManager, *permissionsToRequest)
 
-        permissionFragment?.takeIf { permissionsToRequest.isNotEmpty() }?.run {
+    private fun request(fragmentManager: FragmentManager, vararg permissionsToRequest: String) = flow {
+        createFragment(fragmentManager).takeIf { permissionsToRequest.isNotEmpty() }?.run {
             request(*permissionsToRequest)
             val results = completableDeferred.await()
             if (results.isNotEmpty()) {
-                emit(results.all { it.isGranted })
+                emit(results)
             }
         }
     }
 
-    fun requestEach() = flow {
-        createFragment()
-
-        permissionFragment?.takeIf { permissionsToRequest.isNotEmpty() }?.run {
+    private fun requestEach(fragmentManager: FragmentManager, vararg permissionsToRequest: String) = flow {
+        createFragment(fragmentManager).takeIf { permissionsToRequest.isNotEmpty() }?.run {
             request(*permissionsToRequest)
             val results = completableDeferred.await()
             results.forEach { emit(it) }
         }
     }
 
-    private fun createFragment() = permissionFragment?.let {
-        addFragment(it)
-    } ?: PermissionFragment.newInstance().let {
-        permissionFragment = it
-        addFragment(it)
-    }
-
-    private fun addFragment(fragment: PermissionFragment) {
-        val fragmentManager = activityInFlow?.supportFragmentManager
-            ?: fragmentInFlow?.childFragmentManager
-            ?: throw IllegalArgumentException("To work properly you need to pass an instance of a Fragment or a FragmentActivity")
-
+    private fun createFragment(fragmentManager: FragmentManager) : PermissionFragment {
+        val fragment = fragmentManager.findFragmentByTag(FRAGMENT_TAG)?.let { it as PermissionFragment } ?: PermissionFragment.newInstance()
         fragmentManager
-            .beginTransaction()
-            .apply {
-                if (fragment.isAdded) {
-                    detach(fragment)
+                .beginTransaction()
+                .apply {
+                    if (fragment.isAdded) {
+                        detach(fragment)
+                    }
                 }
-            }
-            .add(fragment, PermissionFragment::class.java.simpleName)
-            .commitNow()
+                .add(fragment, PermissionFragment::class.java.simpleName)
+                .commitNow()
+        return fragment
     }
-
 }
 
-@RequiresApi(Build.VERSION_CODES.M)
-suspend fun permissionFlow(block: suspend PermissionFlow.() -> Unit) {
-    block(PermissionFlow)
-}
+// Extensions
 
-fun PermissionFlow.withPermissions(vararg permissions: String) {
-    permissionsToRequest = permissions
-}
-
-fun PermissionFlow.withFragment(fragment: Fragment) {
-    fragmentInFlow = fragment
-}
-
-fun PermissionFlow.withActivity(activity: FragmentActivity) {
-    activityInFlow = activity
-}
+fun FragmentActivity.requestPermissions(vararg permissionsToRequest: String) = PermissionFlow.request(this, *permissionsToRequest)
+fun FragmentActivity.requestEachPermissions(vararg permissionsToRequest: String) = PermissionFlow.requestEach(this, *permissionsToRequest)
+fun Fragment.requestPermissions(vararg permissionsToRequest: String) = PermissionFlow.request(this, *permissionsToRequest)
+fun Fragment.requestEachPermissions(vararg permissionsToRequest: String) = PermissionFlow.requestEach(this, *permissionsToRequest)

--- a/lib/src/main/java/com/innfinity/permissionflow/lib/PermissionFlow.kt
+++ b/lib/src/main/java/com/innfinity/permissionflow/lib/PermissionFlow.kt
@@ -42,7 +42,7 @@ internal object PermissionFlow {
                         detach(fragment)
                     }
                 }
-                .add(fragment, PermissionFragment::class.java.simpleName)
+                .add(fragment, FRAGMENT_TAG)
                 .commitNow()
         return fragment
     }

--- a/lib/src/main/java/com/innfinity/permissionflow/lib/PermissionFragment.kt
+++ b/lib/src/main/java/com/innfinity/permissionflow/lib/PermissionFragment.kt
@@ -4,6 +4,9 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import androidx.annotation.RequiresApi
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.core.content.PermissionChecker
 import androidx.fragment.app.Fragment
 import kotlinx.coroutines.CompletableDeferred
 
@@ -43,16 +46,15 @@ class PermissionFragment : Fragment() {
         completableDeferred = CompletableDeferred()
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     private fun showRequestPermissionRationale(permission: String) =
-        activity?.run {
-            !isPermissionGranted(permission) && shouldShowRequestPermissionRationale(permission)
+        activity?.let {
+            !isPermissionGranted(permission) && ActivityCompat.shouldShowRequestPermissionRationale(it, permission)
         } ?: false
 
-    @RequiresApi(Build.VERSION_CODES.M)
     private fun isPermissionGranted(permission: String): Boolean =
-        activity?.run { checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED }
-            ?: false
+        activity?.let {
+            PermissionChecker.checkSelfPermission(it, permission) == PermissionChecker.PERMISSION_GRANTED
+        } ?: false
 
     override fun onDestroy() {
         super.onDestroy()

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,0 +1,20 @@
+ext {
+
+    setup = [
+            compileSdk: 30,
+            minSdk    : 21,
+            targetSdk : 30
+    ]
+
+    androidx = [
+            appcompat       : "1.2.0",
+            core            : "1.3.2"
+    ]
+
+    versions = [
+            bintray     : "0.9.2",
+            kotlin      : "1.4.10",
+            gradlePlugin: "4.1.0",
+            coroutine   : "1.4.1"
+    ]
+}

--- a/versions.gradle
+++ b/versions.gradle
@@ -2,7 +2,7 @@ ext {
 
     setup = [
             compileSdk: 30,
-            minSdk    : 21,
+            minSdk    : 23,
             targetSdk : 30
     ]
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -2,7 +2,7 @@ ext {
 
     setup = [
             compileSdk: 30,
-            minSdk    : 23,
+            minSdk    : 21,
             targetSdk : 30
     ]
 


### PR DESCRIPTION
I made a few changes which changes the usage of the library totally, but I think this makes sense.

What I did is following:

* added 4 extension functions for `Fragment` and `FragmentActivity` to expose the `request(Each)Permissions` functions
* disabled the automatic `Permission` to `Permission.isGranted` mapping - it's probably interesting to know to which `Permission` the `isGranted` belongs
* no need to make runtime checks to check if the user has provided a valid `FragmentManager` source
* `PermissionFlow` was holding a strong reference to the `PermissionFragment` - this may lead to memory leaks in multi activity apps
* I disabled bintray for me, I don't use it and did not get it working with it so I disabled it - you need to enable this again please

Optional changes

* I added a `versions.gradle` file as I'm used to this and as I updated all versions for myself

Feel free to reject all version and structure updates if desired, but I'd suggest to accept the code changes or let me know what you think about them.

I kept the `PermissionFlow::requestEach` functions for now but as those only flatten the list I'd suggest to remove them - they are just overhead of the library.